### PR TITLE
:rocket: Update httpRequest to be async

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -262,14 +262,19 @@ httpVueLoader.langProcessor = {
 httpVueLoader.httpRequest = function(url) {
 	
 	return new Promise(function(resolve, reject) {
-
 		var xhr = new XMLHttpRequest();
-		xhr.open('GET', url, false);
+		xhr.open('GET', url);
+		
+		xhr.onreadystatechange = function() {
+			if(xhr.readyState === 4) {
+				if ( xhr.status === 200 )
+				  resolve(xhr.responseText);
+				else
+				  reject(xhr.status);
+			}
+		}
+		
 		xhr.send(null);
-		if ( xhr.status === 200 )
-			resolve(xhr.responseText);
-		else
-			reject(xhr.status);
 	});
 }
 


### PR DESCRIPTION
Updated httpRequest method to use the async version of open. Currently getting a warning when using http-vue-loader in Chrome.

>Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.