### PR TITLE
code cleanup

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -143,14 +143,12 @@ var httpVueLoader = (function() {
 			
 			var childModuleRequire = function(childURL) {
 				
-				childURL = resolveURL(this.component.baseURI, childURL);
-				return httpVueLoader.require(childURL);
+				return httpVueLoader.require(resolveURL(this.component.baseURI, childURL));
 			}.bind(this);
 			
 			var childLoader = function(childURL, childName) {
 				
-				childURL = resolveURL(this.component.baseURI, childURL);
-				return httpVueLoader(childURL, childName);
+				return httpVueLoader(resolveURL(this.component.baseURI, childURL), childName);
 			}.bind(this);
 			
 			try {
@@ -347,11 +345,8 @@ var httpVueLoader = (function() {
 	
 	function resolveURL(baseURL, url) {
 		
-		if (url.substr(0, 2) === './') {
-			return baseURL + url.substr(2);
-		}
-		if (url.substr(0, 3) === '../') {
-			return baseURL + url.substr(3);
+		if (url.substr(0, 2) === './' || url.substr(0, 3) === '../') {
+			return baseURL + url;
 		}
 		return url;
 	}

--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -1,51 +1,52 @@
+'use strict';
+
 var httpVueLoader = (function() {
-	'use strict';
 
 	var scopeIndex = 0;
 
 	StyleContext.prototype = {
-
+		
 		withBase: function(callback) {
 
 			var tmpBaseElt;
 			if ( this.component.baseURI ) {
-
+				
 				// firefox and chrome need the <base> to be set while inserting or modifying <style> in a document.
 				tmpBaseElt = document.createElement('base');
 				tmpBaseElt.href = this.component.baseURI;
-
+				
 				var headElt = this.component.getHead();
 				headElt.insertBefore(tmpBaseElt, headElt.firstChild);
 			}
-
+			
 			callback.call(this);
 
 			if ( tmpBaseElt )
 				this.component.getHead().removeChild(tmpBaseElt);
 		},
-
+		
 		scopeStyles: function(styleElt, scopeName) {
 
 			function process() {
 
 				var sheet = styleElt.sheet;
 				var rules = sheet.cssRules;
-
+				
 				for ( var i = 0; i < rules.length; ++i ) {
-
+					
 					var rule = rules[i];
 					if ( rule.type !== 1 )
 						continue;
-
+					
 					var scopedSelectors = [];
-
+					
 					rule.selectorText.split(/\s*,\s*/).forEach(function(sel) {
-
+						
 						scopedSelectors.push(scopeName+' '+sel);
 						var segments = sel.match(/([^ :]+)(.+)?/);
 						scopedSelectors.push(segments[1] + scopeName + (segments[2]||''));
 					});
-
+					
 					var scopedRule = scopedSelectors.join(',') + rule.cssText.substr(rule.selectorText.length);
 					sheet.deleteRule(i);
 					sheet.insertRule(scopedRule, i);
@@ -56,120 +57,119 @@ var httpVueLoader = (function() {
 				// firefox may fail sheet.cssRules with InvalidAccessError
 				process();
 			} catch (ex) {
-
+				
 				if ( ex instanceof DOMException && ex.code === DOMException.INVALID_ACCESS_ERR ) {
-
+					
 					styleElt.sheet.disabled = true;
 					styleElt.addEventListener('load', function onStyleLoaded() {
 
 						styleElt.removeEventListener('load', onStyleLoaded);
-
+						
 						// firefox need this timeout otherwise we have to use document.importNode(style, true)
 						setTimeout(function() {
-
+				
 							process();
 							styleElt.sheet.disabled = false;
-						});
+						})
 					});
 					return;
 				}
-
+				
 				throw ex;
 			}
 		},
-
+		
 		compile: function() {
-
+			
 			var hasTemplate = this.template !== null;
 
 			var scoped = this.elt.hasAttribute('scoped');
 
 			if ( scoped ) {
-
+				
 				// no template, no scopable style needed
 				if ( !hasTemplate )
 					return;
-
+				
 				// firefox does not tolerate this attribute
 				this.elt.removeAttribute('scoped');
 			}
-
+			
 			this.withBase(function() {
-
+				
 				this.component.getHead().appendChild(this.elt);
 			});
-
+			
 			if ( scoped )
 				this.scopeStyles(this.elt, '['+this.component.getScopeId()+']');
-
+			
 			return Promise.resolve();
 		},
-
+		
 		getContent: function() {
-
+			
 			return this.elt.textContent;
 		},
-
+		
 		setContent: function(content) {
-
+			
 			this.withBase(function() {
-
+			
 				this.elt.textContent = content;
 			});
 		}
-	};
+	}
 
 	function StyleContext(component, elt) {
-
+		
 		this.component = component;
 		this.elt = elt;
 	}
 
 
 	ScriptContext.prototype = {
-
+		
 		getContent: function() {
-
+			
 			return this.elt.textContent;
 		},
-
+		
 		setContent: function(content) {
-
+			
 			this.elt.textContent = content;
 		},
-
+		
 		compile: function(module) {
-
+			
 			var childModuleRequire = function(childUrl) {
-
+				
 				var isRelative = childUrl.substr(0,2) === './' || childUrl.substr(0,3) === '../';
 				return httpVueLoader.require((isRelative ? this.component.baseURI : '') + childUrl);
 			}.bind(this);
-
+			
 			var childLoader = function(childUrl) {
 				if (childUrl.substr(0,2) === './') {
 					childUrl = this.component.baseURI + childUrl.substr(2);
 				}
 				return httpVueLoader(childUrl);
 			}.bind(this);
-
+			
 			try {
-				Function('exports', 'require', 'httpVueLoader', 'module', this.getContent())
-				.call(this.module.exports, this.module.exports, childModuleRequire, childLoader, this.module);
+				Function('exports', 'require', 'httpVueLoader', 'module', this.getContent()).call(this.module.exports, this.module.exports, childModuleRequire, childLoader, this.module);
 			} catch(ex) {
-
+				
 				if ( !('lineNumber' in ex) ) {
-
-					return Promise.reject(ex);
+					
+					return Promise.reject(ex)
 				}
 				var vueFileData = responseText.replace(/\r?\n/g, '\n');
 				var lineNumber = vueFileData.substr(0, vueFileData.indexOf(script)).split('\n').length + ex.lineNumber - 1;
 				throw new (ex.constructor)(ex.message, url, lineNumber);
 			}
-
-			return Promise.resolve(this.module.exports);
+			
+			return Promise.resolve(this.module.exports)
 		}
-	};
+	}
 
 	function ScriptContext(component, elt) {
 
@@ -177,67 +177,67 @@ var httpVueLoader = (function() {
 		this.elt = elt;
 		this.module = { exports:{} };
 	}
-
-
+	
+	
 	TemplateContext.prototype = {
-
+		
 		getContent: function() {
-
+			
 			return this.elt.innerHTML;
 		},
-
+		
 		setContent: function(content) {
-
+			
 			this.elt.innerHTML = content;
 		},
-
+		
 		getRootElt: function() {
-
+			
 			var tplElt = this.elt.content || this.elt;
-
+			
 			if ( 'firstElementChild' in tplElt )
 				return tplElt.firstElementChild;
-
+			
 			for ( tplElt = tplElt.firstChild; tplElt !== null; tplElt = tplElt.nextSibling )
 				if ( tplElt.nodeType === Node.ELEMENT_NODE )
 					return tplElt;
-
+				
 			return null;
 		},
-
+		
 		compile: function() {
-
+			
 			return Promise.resolve();
 		}
-	};
-
+	}
+	
 	function TemplateContext(component, elt) {
 
 		this.component = component;
 		this.elt = elt;
 	}
-
-
-
+	
+	
+	
 	Component.prototype = {
-
+		
 		getHead: function() {
-
+			
 			return document.head || document.getElementsByTagName('head')[0];
 		},
-
+		
 		getScopeId: function() {
-
+			
 			if ( this._scopeId === '' ) {
-
+				
 				this._scopeId = 'data-s-' + (scopeIndex++).toString(36);
 				this.template.getRootElt().setAttribute(this._scopeId, '');
 			}
 			return this._scopeId;
 		},
-
+		
 		load: function(componentUrl) {
-
+			
 			return httpVueLoader.httpRequest(componentUrl)
 			.then(function(responseText) {
 
@@ -248,7 +248,7 @@ var httpVueLoader = (function() {
 				doc.body.innerHTML = (this.baseURI ? '<base href="'+this.baseURI+'">' : '') + responseText;
 
 				for ( var it = doc.body.firstChild; it; it = it.nextSibling ) {
-
+					
 					switch ( it.nodeName ) {
 						case 'TEMPLATE':
 							this.template = new TemplateContext(this, it);
@@ -261,33 +261,33 @@ var httpVueLoader = (function() {
 							break;
 					}
 				}
-
+				
 				return this;
 			}.bind(this));
 		},
-
+		
 		_normalizeSection: function(eltCx) {
-
+			
 			var p;
-
+			
 			if ( eltCx === null || !eltCx.elt.hasAttribute('src') ) {
-
+				
 				p = Promise.resolve(null);
 			} else {
-
+				
 				p = httpVueLoader.httpRequest(eltCx.elt.getAttribute('src'))
 				.then(function(content) {
 
 					eltCx.elt.removeAttribute('src');
 					return content;
-				});
+				})
 			}
-
+			
 			return p
 			.then(function(content) {
-
+				
 				if ( eltCx !== null && eltCx.elt.hasAttribute('lang') ) {
-
+					
 					var lang = eltCx.elt.getAttribute('lang');
 					eltCx.elt.removeAttribute('lang');
 					return httpVueLoader.langProcessor[lang.toLowerCase()](content === null ? eltCx.getContent() : content);
@@ -295,7 +295,7 @@ var httpVueLoader = (function() {
 				return content;
 			})
 			.then(function(content) {
-
+				
 				if ( content !== null )
 					eltCx.setContent(content);
 			});
@@ -309,25 +309,25 @@ var httpVueLoader = (function() {
 				this.styles.map(this._normalizeSection)
 			))
 			.then(function() {
-
+				
 				return this;
 			}.bind(this));
 		},
-
+		
 		compile: function() {
 
 			return Promise.all(Array.prototype.concat(
 				this.template && this.template.compile(),
 				this.script && this.script.compile(),
-				this.styles.map(function(style) { return style.compile(); })
+				this.styles.map(function(style) { return style.compile() })
 			))
 			.then(function() {
-
+				
 				return this;
 			}.bind(this));
 		}
-	};
-
+	}
+	
 	function Component(name) {
 
 		this.name = name;
@@ -336,14 +336,14 @@ var httpVueLoader = (function() {
 		this.styles = [];
 		this._scopeId = '';
 	}
-
+	
 	function parseComponentURL(url) {
 
 		var comp = url.match(/(.*?)([^/]+?)\/?(\.vue)?(?:\?|#|$)/);
 		return {
 			name: comp[2],
 			url: comp[1] + comp[2] + (comp[3] === undefined ? '/index.vue' : comp[3])
-		};
+		}
 	}
 
 
@@ -353,17 +353,17 @@ var httpVueLoader = (function() {
 
 			return new Component(name).load(url)
 			.then(function(component) {
-
+				
 				return component.normalize();
 			})
 			.then(function(component) {
-
+				
 				return component.compile();
 			})
 			.then(function(component) {
-
+				
 				var exports = component.script !== null ? component.script.module.exports : {};
-
+				
 				if ( component.template !== null )
 					exports.template = component.template.getContent();
 
@@ -372,67 +372,67 @@ var httpVueLoader = (function() {
 						exports.name = component.name;
 
 				return exports;
-			});
-		};
-	};
+			})
+		}
+	}
 
 
 	httpVueLoader.register = function(Vue, url) {
-
+		
 		var comp = parseComponentURL(url);
 		Vue.component(comp.name, httpVueLoader.load(comp.url));
-	};
+	}
 
 	httpVueLoader.install = function(Vue) {
-
+		
 		Vue.mixin({
-
+			
 			beforeCreate: function () {
-
+				
 				var components = this.$options.components;
-
+				
 				for ( var componentName in components ) {
-
+					
 					if ( typeof(components[componentName]) === 'string' && components[componentName].substr(0, 4) === 'url:' ) {
 
 						var comp = parseComponentURL(components[componentName].substr(4));
-
+						
 						if ( isNaN(componentName) )
-							components[componentName] = httpVueLoader.load(comp.url, componentName);
+							components[componentName] = httpVueLoader.load(comp.url, componentName);	
 						else
 							components[componentName] = Vue.component(comp.name, httpVueLoader.load(comp.url, comp.name));
 					}
 				}
 			}
 		});
-	};
+	}
 
 	httpVueLoader.require = function(moduleName) {
-
+		
 		return window[moduleName];
-	};
+	}
 
 	httpVueLoader.httpRequest = function(url) {
-
+		
 		return new Promise(function(resolve, reject) {
-
+			
 			var xhr = new XMLHttpRequest();
 			xhr.open('GET', url);
-
+			
 			xhr.onreadystatechange = function() {
-
+				
 				if ( xhr.readyState === 4 ) {
-
+					
 					if ( xhr.status >= 200 && xhr.status < 300 )
 						resolve(xhr.responseText);
 					else
 						reject(xhr.status);
 				}
-			};
-
+			}
+			
 			xhr.send(null);
 		});
-	};
+	}
 
 	httpVueLoader.langProcessor = {};
 
@@ -441,6 +441,6 @@ var httpVueLoader = (function() {
 		var comp = parseComponentURL(url);
 		return httpVueLoader.load(comp.url, name);
 	}
-
+	
 	return httpVueLoader;
 })();

--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -1,52 +1,51 @@
-'use strict';
-
 var httpVueLoader = (function() {
+	'use strict';
 
 	var scopeIndex = 0;
 
 	StyleContext.prototype = {
-		
+
 		withBase: function(callback) {
 
 			var tmpBaseElt;
 			if ( this.component.baseURI ) {
-				
+
 				// firefox and chrome need the <base> to be set while inserting or modifying <style> in a document.
 				tmpBaseElt = document.createElement('base');
 				tmpBaseElt.href = this.component.baseURI;
-				
+
 				var headElt = this.component.getHead();
 				headElt.insertBefore(tmpBaseElt, headElt.firstChild);
 			}
-			
+
 			callback.call(this);
 
 			if ( tmpBaseElt )
 				this.component.getHead().removeChild(tmpBaseElt);
 		},
-		
+
 		scopeStyles: function(styleElt, scopeName) {
 
 			function process() {
 
 				var sheet = styleElt.sheet;
 				var rules = sheet.cssRules;
-				
+
 				for ( var i = 0; i < rules.length; ++i ) {
-					
+
 					var rule = rules[i];
 					if ( rule.type !== 1 )
 						continue;
-					
+
 					var scopedSelectors = [];
-					
+
 					rule.selectorText.split(/\s*,\s*/).forEach(function(sel) {
-						
+
 						scopedSelectors.push(scopeName+' '+sel);
 						var segments = sel.match(/([^ :]+)(.+)?/);
 						scopedSelectors.push(segments[1] + scopeName + (segments[2]||''));
 					});
-					
+
 					var scopedRule = scopedSelectors.join(',') + rule.cssText.substr(rule.selectorText.length);
 					sheet.deleteRule(i);
 					sheet.insertRule(scopedRule, i);
@@ -57,112 +56,120 @@ var httpVueLoader = (function() {
 				// firefox may fail sheet.cssRules with InvalidAccessError
 				process();
 			} catch (ex) {
-				
+
 				if ( ex instanceof DOMException && ex.code === DOMException.INVALID_ACCESS_ERR ) {
-					
+
 					styleElt.sheet.disabled = true;
 					styleElt.addEventListener('load', function onStyleLoaded() {
 
 						styleElt.removeEventListener('load', onStyleLoaded);
-						
+
 						// firefox need this timeout otherwise we have to use document.importNode(style, true)
 						setTimeout(function() {
-				
+
 							process();
 							styleElt.sheet.disabled = false;
-						})
+						});
 					});
 					return;
 				}
-				
+
 				throw ex;
 			}
 		},
-		
+
 		compile: function() {
-			
+
 			var hasTemplate = this.template !== null;
 
 			var scoped = this.elt.hasAttribute('scoped');
 
 			if ( scoped ) {
-				
+
 				// no template, no scopable style needed
 				if ( !hasTemplate )
 					return;
-				
+
 				// firefox does not tolerate this attribute
 				this.elt.removeAttribute('scoped');
 			}
-			
+
 			this.withBase(function() {
-				
+
 				this.component.getHead().appendChild(this.elt);
 			});
-			
+
 			if ( scoped )
 				this.scopeStyles(this.elt, '['+this.component.getScopeId()+']');
-			
+
 			return Promise.resolve();
 		},
-		
+
 		getContent: function() {
-			
+
 			return this.elt.textContent;
 		},
-		
+
 		setContent: function(content) {
-			
+
 			this.withBase(function() {
-			
+
 				this.elt.textContent = content;
 			});
 		}
-	}
+	};
 
 	function StyleContext(component, elt) {
-		
+
 		this.component = component;
 		this.elt = elt;
 	}
 
 
 	ScriptContext.prototype = {
-		
+
 		getContent: function() {
-			
+
 			return this.elt.textContent;
 		},
-		
+
 		setContent: function(content) {
-			
+
 			this.elt.textContent = content;
 		},
-		
+
 		compile: function(module) {
-			
+
 			var childModuleRequire = function(childUrl) {
-				
+
 				var isRelative = childUrl.substr(0,2) === './' || childUrl.substr(0,3) === '../';
 				return httpVueLoader.require((isRelative ? this.component.baseURI : '') + childUrl);
 			}.bind(this);
-			
+
+			var childLoader = function(childUrl) {
+				if (childUrl.substr(0,2) === './') {
+					childUrl = this.component.baseURI + childUrl.substr(2);
+				}
+				return httpVueLoader(childUrl);
+			}.bind(this);
+
 			try {
-				Function('exports', 'require', 'module', this.getContent()).call(this.module.exports, this.module.exports, childModuleRequire, this.module);
+				Function('exports', 'require', 'httpVueLoader', 'module', this.getContent())
+				.call(this.module.exports, this.module.exports, childModuleRequire, childLoader, this.module);
 			} catch(ex) {
-				
+
 				if ( !('lineNumber' in ex) ) {
-					
-					return Promise.reject(ex)
+
+					return Promise.reject(ex);
 				}
 				var vueFileData = responseText.replace(/\r?\n/g, '\n');
 				var lineNumber = vueFileData.substr(0, vueFileData.indexOf(script)).split('\n').length + ex.lineNumber - 1;
 				throw new (ex.constructor)(ex.message, url, lineNumber);
 			}
-			
-			return Promise.resolve(this.module.exports)
+
+			return Promise.resolve(this.module.exports);
 		}
-	}
+	};
 
 	function ScriptContext(component, elt) {
 
@@ -170,67 +177,67 @@ var httpVueLoader = (function() {
 		this.elt = elt;
 		this.module = { exports:{} };
 	}
-	
-	
+
+
 	TemplateContext.prototype = {
-		
+
 		getContent: function() {
-			
+
 			return this.elt.innerHTML;
 		},
-		
+
 		setContent: function(content) {
-			
+
 			this.elt.innerHTML = content;
 		},
-		
+
 		getRootElt: function() {
-			
+
 			var tplElt = this.elt.content || this.elt;
-			
+
 			if ( 'firstElementChild' in tplElt )
 				return tplElt.firstElementChild;
-			
+
 			for ( tplElt = tplElt.firstChild; tplElt !== null; tplElt = tplElt.nextSibling )
 				if ( tplElt.nodeType === Node.ELEMENT_NODE )
 					return tplElt;
-				
+
 			return null;
 		},
-		
+
 		compile: function() {
-			
+
 			return Promise.resolve();
 		}
-	}
-	
+	};
+
 	function TemplateContext(component, elt) {
 
 		this.component = component;
 		this.elt = elt;
 	}
-	
-	
-	
+
+
+
 	Component.prototype = {
-		
+
 		getHead: function() {
-			
+
 			return document.head || document.getElementsByTagName('head')[0];
 		},
-		
+
 		getScopeId: function() {
-			
+
 			if ( this._scopeId === '' ) {
-				
+
 				this._scopeId = 'data-s-' + (scopeIndex++).toString(36);
 				this.template.getRootElt().setAttribute(this._scopeId, '');
 			}
 			return this._scopeId;
 		},
-		
+
 		load: function(componentUrl) {
-			
+
 			return httpVueLoader.httpRequest(componentUrl)
 			.then(function(responseText) {
 
@@ -241,7 +248,7 @@ var httpVueLoader = (function() {
 				doc.body.innerHTML = (this.baseURI ? '<base href="'+this.baseURI+'">' : '') + responseText;
 
 				for ( var it = doc.body.firstChild; it; it = it.nextSibling ) {
-					
+
 					switch ( it.nodeName ) {
 						case 'TEMPLATE':
 							this.template = new TemplateContext(this, it);
@@ -254,33 +261,33 @@ var httpVueLoader = (function() {
 							break;
 					}
 				}
-				
+
 				return this;
 			}.bind(this));
 		},
-		
+
 		_normalizeSection: function(eltCx) {
-			
+
 			var p;
-			
+
 			if ( eltCx === null || !eltCx.elt.hasAttribute('src') ) {
-				
+
 				p = Promise.resolve(null);
 			} else {
-				
+
 				p = httpVueLoader.httpRequest(eltCx.elt.getAttribute('src'))
 				.then(function(content) {
 
 					eltCx.elt.removeAttribute('src');
 					return content;
-				})
+				});
 			}
-			
+
 			return p
 			.then(function(content) {
-				
+
 				if ( eltCx !== null && eltCx.elt.hasAttribute('lang') ) {
-					
+
 					var lang = eltCx.elt.getAttribute('lang');
 					eltCx.elt.removeAttribute('lang');
 					return httpVueLoader.langProcessor[lang.toLowerCase()](content === null ? eltCx.getContent() : content);
@@ -288,7 +295,7 @@ var httpVueLoader = (function() {
 				return content;
 			})
 			.then(function(content) {
-				
+
 				if ( content !== null )
 					eltCx.setContent(content);
 			});
@@ -302,25 +309,25 @@ var httpVueLoader = (function() {
 				this.styles.map(this._normalizeSection)
 			))
 			.then(function() {
-				
+
 				return this;
 			}.bind(this));
 		},
-		
+
 		compile: function() {
 
 			return Promise.all(Array.prototype.concat(
 				this.template && this.template.compile(),
 				this.script && this.script.compile(),
-				this.styles.map(function(style) { return style.compile() })
+				this.styles.map(function(style) { return style.compile(); })
 			))
 			.then(function() {
-				
+
 				return this;
 			}.bind(this));
 		}
-	}
-	
+	};
+
 	function Component(name) {
 
 		this.name = name;
@@ -329,14 +336,14 @@ var httpVueLoader = (function() {
 		this.styles = [];
 		this._scopeId = '';
 	}
-	
+
 	function parseComponentURL(url) {
 
 		var comp = url.match(/(.*?)([^/]+?)\/?(\.vue)?(?:\?|#|$)/);
 		return {
 			name: comp[2],
 			url: comp[1] + comp[2] + (comp[3] === undefined ? '/index.vue' : comp[3])
-		}
+		};
 	}
 
 
@@ -346,17 +353,17 @@ var httpVueLoader = (function() {
 
 			return new Component(name).load(url)
 			.then(function(component) {
-				
+
 				return component.normalize();
 			})
 			.then(function(component) {
-				
+
 				return component.compile();
 			})
 			.then(function(component) {
-				
+
 				var exports = component.script !== null ? component.script.module.exports : {};
-				
+
 				if ( component.template !== null )
 					exports.template = component.template.getContent();
 
@@ -365,67 +372,67 @@ var httpVueLoader = (function() {
 						exports.name = component.name;
 
 				return exports;
-			})
-		}
-	}
+			});
+		};
+	};
 
 
 	httpVueLoader.register = function(Vue, url) {
-		
+
 		var comp = parseComponentURL(url);
 		Vue.component(comp.name, httpVueLoader.load(comp.url));
-	}
+	};
 
 	httpVueLoader.install = function(Vue) {
-		
+
 		Vue.mixin({
-			
+
 			beforeCreate: function () {
-				
+
 				var components = this.$options.components;
-				
+
 				for ( var componentName in components ) {
-					
+
 					if ( typeof(components[componentName]) === 'string' && components[componentName].substr(0, 4) === 'url:' ) {
 
 						var comp = parseComponentURL(components[componentName].substr(4));
-						
+
 						if ( isNaN(componentName) )
-							components[componentName] = httpVueLoader.load(comp.url, componentName);	
+							components[componentName] = httpVueLoader.load(comp.url, componentName);
 						else
 							components[componentName] = Vue.component(comp.name, httpVueLoader.load(comp.url, comp.name));
 					}
 				}
 			}
 		});
-	}
+	};
 
 	httpVueLoader.require = function(moduleName) {
-		
+
 		return window[moduleName];
-	}
+	};
 
 	httpVueLoader.httpRequest = function(url) {
-		
+
 		return new Promise(function(resolve, reject) {
-			
+
 			var xhr = new XMLHttpRequest();
 			xhr.open('GET', url);
-			
+
 			xhr.onreadystatechange = function() {
-				
+
 				if ( xhr.readyState === 4 ) {
-					
+
 					if ( xhr.status >= 200 && xhr.status < 300 )
 						resolve(xhr.responseText);
 					else
 						reject(xhr.status);
 				}
-			}
-			
+			};
+
 			xhr.send(null);
 		});
-	}
+	};
 
 	httpVueLoader.langProcessor = {};
 
@@ -434,6 +441,6 @@ var httpVueLoader = (function() {
 		var comp = parseComponentURL(url);
 		return httpVueLoader.load(comp.url, name);
 	}
-	
+
 	return httpVueLoader;
 })();

--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -141,17 +141,16 @@ var httpVueLoader = (function() {
 		
 		compile: function(module) {
 			
-			var childModuleRequire = function(childUrl) {
+			var childModuleRequire = function(childURL) {
 				
-				var isRelative = childUrl.substr(0,2) === './' || childUrl.substr(0,3) === '../';
-				return httpVueLoader.require((isRelative ? this.component.baseURI : '') + childUrl);
+				childURL = resolveURL(this.component.baseURI, childURL);
+				return httpVueLoader.require(childURL);
 			}.bind(this);
 			
-			var childLoader = function(childUrl) {
-				if (childUrl.substr(0,2) === './') {
-					childUrl = this.component.baseURI + childUrl.substr(2);
-				}
-				return httpVueLoader(childUrl);
+			var childLoader = function(childURL, childName) {
+				
+				childURL = resolveURL(this.component.baseURI, childURL);
+				return httpVueLoader(childURL, childName);
 			}.bind(this);
 			
 			try {
@@ -345,8 +344,19 @@ var httpVueLoader = (function() {
 			url: comp[1] + comp[2] + (comp[3] === undefined ? '/index.vue' : comp[3])
 		}
 	}
-
-
+	
+	function resolveURL(baseURL, url) {
+		
+		if (url.substr(0, 2) === './') {
+			return baseURL + url.substr(2);
+		}
+		if (url.substr(0, 3) === '../') {
+			return baseURL + url.substr(3);
+		}
+		return url;
+	}
+	
+	
 	httpVueLoader.load = function(url, name) {
 
 		return function() {


### PR DESCRIPTION
Moved 'use strict;' inside the function. [This prevents problems when concatenating scripts that aren't strict.](https://stackoverflow.com/questions/4462478/jslint-is-suddenly-reporting-use-the-function-form-of-use-strict)
Removed unnecessary whitespaces.
Replaced `Url` with `URL` for consistency. [Why `URL` and not `Url`? ](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL)
Inserted missing semicolons.
