### PR TITLE
Support AMD-style export

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -170,7 +170,17 @@
 				throw new (ex.constructor)(ex.message, url, lineNumber);
 			}
 
-			return Promise.resolve(this.module.exports)
+			return new Promise(function(resolve) {
+
+				if ( typeof define !== 'function' || !define.amd )
+					return resolve();
+
+				require([ this.component.name ], function(component) {
+
+					this.module.exports = component.default;
+					resolve();
+				}.bind(this));
+			})
 			.then(function(exports) {
 
 				this.module.exports = exports;

--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -307,10 +307,10 @@
 
 					var lang = eltCx.elt.getAttribute('lang');
 					eltCx.elt.removeAttribute('lang');
-					return httpVueLoader.langProcessor[lang.toLowerCase()](content === null ? eltCx.getContent() : content);
+					return httpVueLoader.langProcessor[lang.toLowerCase()].call(this, content === null ? eltCx.getContent() : content);
 				}
 				return content;
-			})
+			}.bind(this))
 			.then(function(content) {
 
 				if ( content !== null )


### PR DESCRIPTION
This PR aims to support AMD-style export. Let's say we have a module that defines inside Vue component.

```vue
<template>
    <div>
        <article v-for="item in items">{{ body }}</article>
    </div>
</template>

<!-- 'babel' transforms the code below to AMD **for example** -->
<script lang="babel">
import Vuex from 'vuex';

export default {
    name: 'FooItem',
    computed: {
        ...Vuex.mapState([
            'items',
        ]),
    },
};
</script>
```

and we implement `'babel'` using babel-standalone by AMD manner:

```javascript
define(['babel-standalone', 'http-vue-loader'], function (Babel, httpVueLoader) {
    httpVueLoader.langProcessor.babel = function (script) {
        return Babel.transform(script, {
            moduleId: this.name,
            presets: [
                'es2017',
                'stage-3',
            ],
            plugins: [
                'transform-es2015-modules-amd',
            ],
        }).code;
    };

    return {
        load: function (name, req, onload, config) {
            httpVueLoader(req.toUrl(name) + ".vue", name)().then(onload);
        },
    };
});
```

The commit includes a slight change in `ScriptContext` in order that it waits for AMD `require`.