### PR TITLE
Add scriptExportsHandler to support flexible module resolution (#36)

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -297,10 +297,10 @@
 
 					var lang = eltCx.elt.getAttribute('lang');
 					eltCx.elt.removeAttribute('lang');
-					return httpVueLoader.langProcessor[lang.toLowerCase()](content === null ? eltCx.getContent() : content);
+					return httpVueLoader.langProcessor[lang.toLowerCase()].call(this, content === null ? eltCx.getContent() : content);
 				}
 				return content;
-			})
+			}.bind(this))
 			.then(function(content) {
 
 				if ( content !== null )

--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -171,6 +171,7 @@
 			}
 
 			return Promise.resolve(this.module.exports)
+			.then(httpVueLoader.scriptExportsHandler.bind(this))
 			.then(function(exports) {
 
 				this.module.exports = exports;
@@ -463,6 +464,8 @@
 		js: identity,
 		css: identity
 	};
+
+	httpVueLoader.scriptExportsHandler = identity;
 
 	function httpVueLoader(url, name) {
 


### PR DESCRIPTION
This PR fixes `httpVueLoader.langProcessor` and adds `httpVueLoader.scriptExportsHandler` (at the suggestion of @FranckFreiburger), so that this loader supports some other module systems such as AMD in the `<script>` section.

Merging the PR enables developers to
- access `this` instance of `Component` from `httpVueLoader.langProcessor`
- customize a behavior of what is done when module is exported

For instance, a piece of code like below helps them debug more complicated modules such that includes other Vue components in hand.

```js
httpVueLoader.scriptExportsHandler = function (script) {
    return new Promise(function (resolve) {
        require([ this.component.name ], function (component) {
            resolve(component.default);
        });
    }.bind(this));
};
```

See #36 for more detail.