### PR TITLE
Avoid XML Parsing Error

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -442,6 +442,7 @@
 		return new Promise(function(resolve, reject) {
 
 			var xhr = new XMLHttpRequest();
+            		xhr.responseType = 'text';
 			xhr.open('GET', url);
 
 			xhr.onreadystatechange = function() {


### PR DESCRIPTION
Using http-vue-loader on apache or xampp, http-vue-loader successfully load component but using firefox show an "XML Parsing Error: "Junk" after end of document" error for every component loaded.

The update fix the error.