### PR TITLE
Added support for data-urls

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -249,7 +249,7 @@
 			return httpVueLoader.httpRequest(componentURL)
 			.then(function(responseText) {
 
-				this.baseURI = componentURL.substr(0, componentURL.lastIndexOf('/')+1);
+				this.baseURI = (componentURL.substr(0, 5) === 'data:' ? '' : componentURL.substr(0, componentURL.lastIndexOf('/')+1));
 				var doc = document.implementation.createHTMLDocument('');
 
 				// IE requires the <base> to come with <style>
@@ -355,7 +355,7 @@
 		var comp = url.match(/(.*?)([^/]+?)\/?(\.vue)?(\?.*|#.*|$)/);
 		return {
 			name: comp[2],
-			url: comp[1] + comp[2] + (comp[3] === undefined ? '/index.vue' : comp[3]) + comp[4]
+			url: comp[1] + comp[2] + (comp[3] === undefined ? (comp[1].substr(0, 5) !== 'data:' ? '/index.vue' : '') : comp[3]) + comp[4]
 		};
 	}
 


### PR DESCRIPTION
Added support for data-urls:
- '/index.vue' is not appended to data-urls
- baseURI is empty to not include a base tag for data-urls

Data-URLs are really useful when you dont want to make extra web requests because you already have the complete content of a vue sfc.

I use this in combination with PHP to pre-include all needed components via base64-data-urls.
This is much more useful than only including a local "text/x-template" because a vue component can now also have scripts and styles.