### PR TITLE
Use 'self' if 'root' is undefined

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -4,7 +4,7 @@
 	else if(typeof define==='function' && define.amd)
 		define([],factory)
 	else
-		root.httpVueLoader=factory()
+		(root = root || self, root.httpVueLoader=factory())
 })(this,function factory() {
 	'use strict';
 


### PR DESCRIPTION
I try to load libs with `import()`:
```
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <script>
        function bootstrap() {
            // load all libraries then create & start application
            Promise.all([
                import("./lib/http_vue_loader.js"),
                import("./lib/vue-router.js"),
                import("./lib/vue_esm_browser.js"),
            ]).then(([modLoader, modRouter, modVue, ...other]) => {
                debugger;
            });
        }

        window.addEventListener("load", () => bootstrap());
    </script>
</head>
<body>
</body>
</html>
```

but `root` is undefined in this case:
```
(function umd(root,factory){
    if(typeof module==='object' && typeof exports === 'object' )
        module.exports=factory()
    else if(typeof define==='function' && define.amd)
        define([],factory)
    else
        root.httpVueLoader=factory()
})(this,function factory() {...});
``` 

and I have an error "Cannot set property 'httpVueLoader' of undefined" at
```
root.httpVueLoader=factory()
```

`vue-router.js` uses [self](https://developer.mozilla.org/en-US/docs/Web/API/Window/self) in the same situation.