### PR TITLE
去掉必须为.vue文件的限制，解决网站因MIME限制导致下载vue失败的问题

### DIFF
--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -351,12 +351,7 @@
 	}
 
 	function parseComponentURL(url) {
-
-		var comp = url.match(/(.*?)([^/]+?)\/?(\.vue)?(\?.*|#.*|$)/);
-		return {
-			name: comp[2],
-			url: comp[1] + comp[2] + (comp[3] === undefined ? '/index.vue' : comp[3]) + comp[4]
-		};
+        return url
 	}
 
 	function resolveURL(baseURL, url) {

--- a/src/httpVueLoader.js
+++ b/src/httpVueLoader.js
@@ -351,7 +351,8 @@
 	}
 
 	function parseComponentURL(url) {
-        return url
+        var name = url.match(/\/(.+)\.vue[^\/]*$/)[1]
+        return {url: url, name: name}
 	}
 
 	function resolveURL(baseURL, url) {


### PR DESCRIPTION
去掉必须为.vue文件的限制，解决网站因MIME限制导致下载vue失败的问题